### PR TITLE
Fix a type error in client::HttpResponse

### DIFF
--- a/src/googleapis/client/transport/http_response.cc
+++ b/src/googleapis/client/transport/http_response.cc
@@ -87,7 +87,7 @@ void HttpResponse::Clear() {
 }
 
 const string* HttpResponse::FindHeaderValue(const StringPiece& name) const {
-  HttpHeaderMap::const_iterator found = headers_.find(name.as_string());
+  HttpHeaderMultiMap::const_iterator found = headers_.find(name.as_string());
   return (found == headers_.end()) ? NULL : &found->second;
 }
 


### PR DESCRIPTION
"headers_" was defined as HttpHeaderMultiMap, not HttpHeaderMap. It may fail compilation in some in some situations.